### PR TITLE
Add clang-tidy warnings, fixes, and CI

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,4 @@
+---
+Checks: "*"
+WarningsAsErrors: '*'
+...

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,4 +1,8 @@
 ---
-Checks: "*"
+Checks: '*\
+-cppcoreguidelines-avoid-c-arrays,-hicpp-avoid-c-arrays,-modernize-avoid-c-arrays,\
+-google-runtime-int,\
+-modernize-use-trailing-return-type,\
+'
 WarningsAsErrors: '*'
 ...

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,14 +5,36 @@ on:
     branches:
       - master
     tags:
-      - '[0-9]+.*'
+      - 'v[0-9]+.*'
   pull_request:
     branches:
       - master
 
 jobs:
+  lint:
+    name: Lint
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Get latest CMake and ninja
+        uses: lukka/get-cmake@latest
+
+      - name: Install clang-tidy
+        run: sudo apt-get install clang-tidy -y -q
+
+      - name: Configure
+        shell: pwsh
+        run: cmake --preset=ci-lint
+
+      - name: Build
+        run: cmake --build build
+
   examples:
     name: Examples
+    needs: [ lint ]
     runs-on: ubuntu-latest
 
     steps:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,10 +61,7 @@ add_library(
 target_include_directories(
     perturb ${warning_guard}
     PUBLIC
-        $<INSTALL_INTERFACE:include>
         $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
-    PRIVATE
-        ${CMAKE_CURRENT_SOURCE_DIR}/src
 )
 
 target_compile_features(perturb PUBLIC cxx_std_11)

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -30,6 +30,13 @@
       }
     },
     {
+      "name": "clang-tidy",
+      "hidden": true,
+      "cacheVariables": {
+        "CMAKE_CXX_CLANG_TIDY": "clang-tidy;--header-filter=${sourceDir}/*"
+      }
+    },
+    {
       "name": "ci-std",
       "description": "This preset makes sure perturb actually builds with C++11",
       "hidden": true,
@@ -87,9 +94,16 @@
       "inherits": ["ci-build", "ci-win64", "dev-mode"]
     },
     {
+      "name": "ci-lint",
+      "inherits": ["ci-build", "ci-unix", "dev-mode", "clang-tidy"],
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug"
+      }
+    },
+    {
       "name": "dev-unix",
       "binaryDir": "${sourceDir}/build/dev-unix",
-      "inherits": ["dev-mode", "ci-unix"],
+      "inherits": ["dev-mode", "clang-tidy", "ci-unix"],
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "Debug"
       }
@@ -97,7 +111,7 @@
     {
       "name": "dev-win64",
       "binaryDir": "${sourceDir}/build/dev-win64",
-      "inherits": ["dev-mode", "ci-win64"]
+      "inherits": ["dev-mode", "clang-tidy", "ci-win64"]
     }
   ]
 }

--- a/include/perturb/vallado_sgp4.hpp
+++ b/include/perturb/vallado_sgp4.hpp
@@ -61,6 +61,10 @@
 #error "Cannot enable SGP4 debug without I/O functionality"
 #endif
 
+// NOLINTBEGIN(cppcoreguidelines-avoid-magic-numbers, readability-magic-numbers
+// NOLINTBEGIN(readability-avoid-const-params-in-decls)
+
+// NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
 #define PERTURB_VALLADO_SGP4_SGP4Version  "SGP4 Version 2020-07-13"
 
 namespace perturb {
@@ -74,14 +78,14 @@ namespace perturb {
 namespace vallado_sgp4 {
 
 // -------------------------- structure declarations ----------------------------
-typedef enum
+typedef enum   // NOLINT(modernize-use-using)
 {
   wgs72old,
   wgs72,
   wgs84
 } gravconsttype;
 
-typedef struct elsetrec
+typedef struct elsetrec  // NOLINT(modernize-use-using,altera-struct-pack-align)
 {
   char      satnum[6];
   int       epochyr, epochtynumrev;
@@ -249,5 +253,8 @@ typedef struct elsetrec
 
 }  // namespace vallado_sgp4
 }  // namespace perturb
+
+// NOLINTEND(cppcoreguidelines-avoid-magic-numbers, readability-magic-numbers
+// NOLINTEND(readability-avoid-const-params-in-decls)
 
 #endif  // PERTURB_VALLADO_SGP4_HPP

--- a/src/vallado_sgp4.cpp
+++ b/src/vallado_sgp4.cpp
@@ -57,11 +57,15 @@
 
 #include "perturb/vallado_sgp4.hpp"
 
+// NOLINTBEGIN(cppcoreguidelines-avoid-magic-numbers, readability-magic-numbers)
+
+// NOLINTBEGIN(hicpp-deprecated-headers, modernize-deprecated-headers)
 #include <math.h>
 #include <stdio.h>
 #include <string.h>
+// NOLINTEND(hicpp-deprecated-headers, modernize-deprecated-headers)
 
-#define pi 3.14159265358979323846
+#define pi 3.14159265358979323846  // NOLINT(cppcoreguidelines-macro-usage)
 
 namespace perturb {
 namespace vallado_sgp4 {
@@ -1282,7 +1286,10 @@ double& rp, double& rteosq, double& sinio, double& gsto, char opsmode
         c1p2p = c1 + twopi;
         double gsto1 = fmod(thgr70 + c1*ds70 + c1p2p*tfrac + ts70*ts70*fk5r, twopi);
         if (gsto1 < 0.0)
+        {
             gsto1 = gsto1 + twopi;
+        }
+        (void) gsto1;  // Seems like most of the above isn't even used lol
         //    }
         //    else
         gsto = gstime_SGP4(epoch + 2433281.5);
@@ -1877,6 +1884,7 @@ double& rp, double& rteosq, double& sinio, double& gsto, char opsmode
         xlm = mm + argpm + nodem;
         emsq = em * em;
         temp = 1.0 - emsq;
+        (void) temp;
 
         nodem = fmod(nodem, twopi);
         argpm = fmod(argpm, twopi);
@@ -1958,6 +1966,8 @@ double& rp, double& rteosq, double& sinio, double& gsto, char opsmode
         eo1 = u;
         tem5 = 9999.9;
         ktr = 1;
+        coseo1 = 1;  // To shut up clang's static analyzer
+        sineo1 = 1;
         //   sgp4fix for kepler iteration
         //   the following iteration needs better limits on corrections
         while ((fabs(tem5) >= 1.0e-12) && (ktr <= 10))
@@ -3271,3 +3281,5 @@ double& rp, double& rteosq, double& sinio, double& gsto, char opsmode
 
 }  // namesapce vallado_sgp4
 }  // namespace perturb
+
+// NOLINTEND(cppcoreguidelines-avoid-magic-numbers, readability-magic-numbers)

--- a/src/vallado_sgp4.cpp
+++ b/src/vallado_sgp4.cpp
@@ -1452,12 +1452,15 @@ double& rp, double& rteosq, double& sinio, double& gsto, char opsmode
 
         satrec.error = 0;
         satrec.operationmode = opsmode;
-        // FIXME: Figure out better way to do this string copy
         // new alpha5 or 9-digit number
         #ifdef _MSC_VER
                            strcpy_s(satrec.satnum, 6 * sizeof(char), satn);
         #else
-                           strcpy(satrec.satnum, satn);
+                           // If `satn` is shorter than five, NUL appears earlier.
+                           // Otherwise, `satn` is truncated to first five chars.
+                           // In all cases, `satrec.satnum` is a valid string after.
+                           memcpy(satrec.satnum, satn, 5 * sizeof(char));
+                           satrec.satnum[5] = '\0';
         #endif
 
         // sgp4fix - note the following variables are also passed directly via satrec.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -6,6 +6,12 @@ endif()
 
 project(test_perturb LANGUAGES CXX)
 
+# A hack to disable warnings for any targets except perturb
+if(DEFINED CMAKE_CXX_CLANG_TIDY)
+    set(CMAKE_CXX_CLANG_TIDY_save "${CMAKE_CXX_CLANG_TIDY}")
+    set(CMAKE_CXX_CLANG_TIDY "")
+endif()
+
 include(FetchContent)
 FetchContent_Declare(
     doctest
@@ -16,6 +22,11 @@ FetchContent_MakeAvailable(doctest)
 
 add_executable(test_perturb test_perturb.cpp)
 target_link_libraries(test_perturb PRIVATE perturb doctest)
+
+# Restore previous
+if(DEFINED CMAKE_CXX_CLANG_TIDY_save)
+    set(CMAKE_CXX_CLANG_TIDY "${CMAKE_CXX_CLANG_TIDY_save}")
+endif()
 
 target_compile_features(test_perturb PRIVATE cxx_std_11)
 set_target_properties(

--- a/tests/test_perturb.cpp
+++ b/tests/test_perturb.cpp
@@ -1,5 +1,5 @@
 #define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
-#include "doctest/doctest.h"
+#include <doctest/doctest.h>
 
 #include <array>
 #include <cstdio>


### PR DESCRIPTION
Sets up clang-tidy warnings, fixes em in the code, and adds it to CI.

Does part of #10