### PR TITLE
`const` correctness and support for `std::chrono`

### DIFF
--- a/include/perturb/perturb.hpp
+++ b/include/perturb/perturb.hpp
@@ -279,12 +279,33 @@ public:
     /// Left as mutable instead of internally copying for efficiency reasons as
     /// this may be okay for the caller.
     ///
+    /// @param line_1 First line of TLE as C-string
+    /// @param line_1 Size of the first line
+    /// @param line_2 Second line of TLE as C-string
+    /// @param line_2 Size of the first line
+    /// @param grav_model Gravity constants to use (default `GravModel::WGS72`)
+    /// @return An initialized `Satellite`
+    static Satellite from_tle(
+        const char* line_1, size_t line_1_len, 
+        const char* line_2, size_t line_2_len, 
+        GravModel grav_model
+    );
+#endif  // PERTURB_DISABLE_IO
+
+#ifndef PERTURB_DISABLE_IO
+    /// Construct and initialize a `Satellite` from a TLE record.
+    ///
+    /// The strings are mutable because the underlying implementation in
+    /// `perturb::sgp4::twoline2rv` may modify the string during parsing.
+    /// Left as mutable instead of internally copying for efficiency reasons as
+    /// this may be okay for the caller.
+    ///
     /// @param line_1 First line of TLE as C-string of length `perturb::TLE_LINE_LEN`
     /// @param line_2 Second line of TLE as C-string of length `perturb::TLE_LINE_LEN`
     /// @param grav_model Gravity constants to use (default `GravModel::WGS72`)
     /// @return An initialized `Satellite`
     static Satellite from_tle(
-        char *line_1, char *line_2, GravModel grav_model = GravModel::WGS72
+        const char *line_1, const char *line_2, GravModel grav_model = GravModel::WGS72
     );
 #endif  // PERTURB_DISABLE_IO
 
@@ -296,7 +317,7 @@ public:
     /// @param grav_model Gravity constants to use (default `GravModel::WGS72`)
     /// @return An initialized `Satellite`
     static Satellite from_tle(
-        std::string &line_1, std::string &line_2, GravModel grav_model = GravModel::WGS72
+        const std::string &line_1, const std::string &line_2, GravModel grav_model = GravModel::WGS72
     );
 #endif  // PERTURB_DISABLE_IO
 

--- a/include/perturb/perturb.hpp
+++ b/include/perturb/perturb.hpp
@@ -22,6 +22,7 @@
 #include "perturb/tle.hpp"
 
 #include <array>
+#include <chrono>
 #ifndef PERTURB_DISABLE_IO
 #  include <string>
 #endif
@@ -330,16 +331,30 @@ public:
     /// Propagate the SGP4 model based on time around the epoch.
     ///
     /// @param mins_from_epoch Offset number of minutes around the epoch
-    /// @param posvel Returned state vector in the TEME frame
+    /// @param sv OUTPUT: The state vector of the satellite at the provided time
     /// @return Issues during propagation, should usually be `Sgp4Error::NONE`
     Sgp4Error propagate_from_epoch(double mins_from_epoch, StateVector &sv);
+
+    /// Propagate the SGP4 model based on the time around the epoch.
+    ///
+    /// @param time_epoch The time from the epoch in the native system clock
+    /// @param sv OUTPUT: The state vector of the satellite at the provided time
+    ///@return Issues during propagation, should usually be `Sgp4Error::NONE`
+    Sgp4Error propagate_from_epoch(std::chrono::system_clock::duration time_epoch, StateVector &sv);
 
     /// Propagate the SGP4 model to a specific time point.
     ///
     /// @param jd Time point in UTC or UT1
-    /// @param posvel Returned state vector in the TEME frame
+    /// @param sv OUTPUT: The state vector of the satellite at the provided time
     /// @return Issues during propagation, should usually be `Sgp4Error::NONE`
     Sgp4Error propagate(JulianDate jd, StateVector &sv);
+
+    /// Propagate the SGP4 model to a specific time point.
+    ///
+    /// @param time The system clocks time
+    /// @param sv OUTPUT: The state vector of the satellite at the provided time
+    /// @return Issues during propagation, should usually be `Sgp4Error::NONE`
+    Sgp4Error propagate(std::chrono::system_clock::time_point time, StateVector &sv);
 };
 }  // namespace perturb
 

--- a/include/perturb/perturb.hpp
+++ b/include/perturb/perturb.hpp
@@ -275,17 +275,14 @@ public:
 #ifndef PERTURB_DISABLE_IO
     /// Construct and initialize a `Satellite` from a TLE record.
     ///
-    /// The strings are mutable because the underlying implementation in
-    /// `perturb::sgp4::twoline2rv` may modify the string during parsing.
-    /// Left as mutable instead of internally copying for efficiency reasons as
-    /// this may be okay for the caller.
-    ///
     /// @param line_1 First line of TLE as C-string
     /// @param line_1 Size of the first line
     /// @param line_2 Second line of TLE as C-string
     /// @param line_2 Size of the first line
     /// @param grav_model Gravity constants to use (default `GravModel::WGS72`)
-    /// @return An initialized `Satellite`
+    /// @return An initialized `Satellite` or:
+    ///   - `Sgp4Error::UNKNOWN` if `line_1` or `line_2` are `nullptr`
+    ///   - `Sgp4Error::INVALID_TLE` if `line_1_len` or `line_2_len` are not long enough for a TLE file
     static Satellite from_tle(
         const char* line_1, size_t line_1_len, 
         const char* line_2, size_t line_2_len, 
@@ -296,15 +293,12 @@ public:
 #ifndef PERTURB_DISABLE_IO
     /// Construct and initialize a `Satellite` from a TLE record.
     ///
-    /// The strings are mutable because the underlying implementation in
-    /// `perturb::sgp4::twoline2rv` may modify the string during parsing.
-    /// Left as mutable instead of internally copying for efficiency reasons as
-    /// this may be okay for the caller.
-    ///
-    /// @param line_1 First line of TLE as C-string of length `perturb::TLE_LINE_LEN`
-    /// @param line_2 Second line of TLE as C-string of length `perturb::TLE_LINE_LEN`
+    /// @param line_1 First line of TLE as C-string (null-terminated) of length `perturb::TLE_LINE_LEN`
+    /// @param line_2 Second line of TLE as C-string of length (null-terminated) `perturb::TLE_LINE_LEN`
     /// @param grav_model Gravity constants to use (default `GravModel::WGS72`)
     /// @return An initialized `Satellite`
+    ///   - `Sgp4Error::UNKNOWN` if `line_1` or `line_2` are `nullptr`
+    ///   - `Sgp4Error::INVALID_TLE` if `line_1` or `line_2` are not long enough for a TLE file
     static Satellite from_tle(
         const char *line_1, const char *line_2, GravModel grav_model = GravModel::WGS72
     );
@@ -338,7 +332,7 @@ public:
     /// Propagate the SGP4 model based on the time around the epoch.
     ///
     /// @param time_epoch The time from the epoch in the native system clock
-    /// @param sv OUTPUT: The state vector of the satellite at the provided time
+    /// @param sv OUTPUT: The state vector of the satellite at the provided time in the TEME frame
     ///@return Issues during propagation, should usually be `Sgp4Error::NONE`
     Sgp4Error propagate_from_epoch(std::chrono::system_clock::duration time_epoch, StateVector &sv);
 

--- a/include/perturb/perturb.hpp
+++ b/include/perturb/perturb.hpp
@@ -144,6 +144,11 @@ struct JulianDate {
     /// @param t Time point, must be from 1900 to 2100
     explicit JulianDate(DateTime t);
 
+    /// Construct from a system clock time point (unix time).
+    ///
+    /// @param t system clock time
+    explicit JulianDate(std::chrono::system_clock::time_point t);
+
     /// Convert to a `DateTime` representing the same time point.
     ///
     /// @return Same time point converted to a human readable representation
@@ -190,6 +195,11 @@ struct JulianDate {
     /// Compare if after than or same as another time point
     bool operator>=(const JulianDate &rhs) const;
 };
+
+/// Converts a system (unix) time to julian time
+///
+/// @param time system clock time point (unix time)
+JulianDate to_julian(std::chrono::system_clock::time_point time);
 
 /// Represents the output prediction from SGP4.
 ///

--- a/src/perturb.cpp
+++ b/src/perturb.cpp
@@ -13,6 +13,7 @@
 
 #include <cmath>
 #include <cstring>
+#include <cstdint>
 
 #include "perturb/sgp4.hpp"
 
@@ -252,6 +253,12 @@ Sgp4Error Satellite::propagate_from_epoch(double mins_from_epoch, StateVector &s
     return last_error();
 }
 
+Sgp4Error Satellite::propagate_from_epoch(std::chrono::system_clock::duration time_epoch, StateVector &sv){
+    using float_minutes = std::chrono::duration<double, std::ratio<60>>;
+    const double mins_from_epoch = std::chrono::duration_cast<float_minutes>(time_epoch).count();
+    return this->propagate_from_epoch(mins_from_epoch, sv);
+}
+
 Sgp4Error Satellite::propagate(const JulianDate jd, StateVector &sv) {
     const double delta_jd = jd - epoch();
     const double mins_from_epoch = delta_jd * MINS_PER_DAY;
@@ -259,4 +266,43 @@ Sgp4Error Satellite::propagate(const JulianDate jd, StateVector &sv) {
     sv.epoch = jd;  // Can save some math, ignore value from `propagate_from_epoch`
     return err;
 }
+
+Sgp4Error Satellite::propagate(std::chrono::system_clock::time_point time, StateVector &sv){
+    using int_days = std::chrono::duration<std::int64_t, std::ratio<86400>>;
+    using float_days = std::chrono::duration<double, std::ratio<86400>>;
+
+    // convert in system clock integers to mitigate information loss during conversion
+    const std::chrono::system_clock::duration since_epoch = time.time_since_epoch();
+    int_days days_since_unix_epoch = std::chrono::duration_cast<int_days>(since_epoch);
+    std::chrono::system_clock::duration residual_day_since_unix_epoch = since_epoch - std::chrono::duration_cast<std::chrono::system_clock::duration>(days_since_unix_epoch);
+
+    // fix rounding so that duration cast behaves like floor
+    if(residual_day_since_unix_epoch < std::chrono::system_clock::duration(0)){
+        days_since_unix_epoch -= int_days(1);
+        residual_day_since_unix_epoch += int_days(1);
+    }
+
+    // convert days to julian
+    // Unix epoch:
+    // 1970-01-01 00:00:00 UTC = JD 2440587.5
+    int_days julian_days = days_since_unix_epoch + int_days(2440587);
+
+    // convert residual to julian residual
+    std::chrono::system_clock::duration residual = residual_day_since_unix_epoch + std::chrono::hours(12);
+    
+    // Normalize JD fraction into [0, 1).
+    if(residual >= int_days(1)){
+        julian_days += int_days(1);
+        residual -= int_days(1);
+    }
+
+    // convert from integers to double
+    const double jd_days = static_cast<double>(julian_days.count());
+    const double jd_fraction = std::chrono::duration_cast<float_days>(residual).count();
+
+    const JulianDate jd(jd_days, jd_fraction);
+
+    return this->propagate(jd, sv);
+}
+
 }  // namespace perturb

--- a/src/perturb.cpp
+++ b/src/perturb.cpp
@@ -186,34 +186,53 @@ Satellite::Satellite(const TwoLineElement &tle, GravModel grav_model) : sat_rec(
 }
 
 #ifndef PERTURB_DISABLE_IO
-Satellite Satellite::from_tle(char *line_1, char *line_2, GravModel grav_model) {
-    sgp4::elsetrec sat_rec {};
-    const bool bad_ptrs = !line_1 || !line_2;
-    // FIXME: Remove `strlen` and just check last byte
-    if (bad_ptrs || std::strlen(line_1) < TLE_LINE_LEN
-        || std::strlen(line_2) < TLE_LINE_LEN) {
-        sat_rec.error = static_cast<int>(Sgp4Error::INVALID_TLE);
-    } else {
-        // FIXME: Change default TLE to own parser, check downstream usage for assumptions
+    Satellite Satellite::from_tle(const char* line_1, size_t line_1_len, const char* line_2, size_t line_2_len, GravModel grav_model){
+        sgp4::elsetrec sat_rec {};
+        if((line_1_len < TLE_LINE_LEN) || (line_2_len < TLE_LINE_LEN)){
+            sat_rec.error = static_cast<int>(Sgp4Error::INVALID_TLE);
+            return Satellite(sat_rec);
+        }
+
+        // copy into buffers to:
+        //   1) not have side effects on the input data
+        //   2) make sure the line strings are null terminated strings and not snippets out of a larger file
+        char line_1_buffer[130];
+        const size_t n1 = (129 < line_1_len) ? 129 : line_1_len;
+        std::strncpy(line_1_buffer, line_1, n1);
+        line_1_buffer[n1] = '\0';
+
+        char line_2_buffer[130];
+        const size_t n2 = (129 < line_2_len) ? 129 : line_2_len;
+        std::strncpy(line_2_buffer, line_2, n2);
+        line_2_buffer[n2] = '\0';
+
         double _startmfe, _stopmfe, _deltamin;
         sgp4::twoline2rv(
-            line_1, line_2, ' ', ' ', 'i', convert_grav_model(grav_model), _startmfe,
+            line_1_buffer, line_2_buffer, ' ', ' ', 'i', convert_grav_model(grav_model), _startmfe,
             _stopmfe, _deltamin, sat_rec
         );
+
+        return Satellite(sat_rec);
     }
-    return Satellite(sat_rec);
+#endif  // PERTURB_DISABLE_IO
+
+#ifndef PERTURB_DISABLE_IO
+Satellite Satellite::from_tle(const char *line_1, const char *line_2, GravModel grav_model) {
+    sgp4::elsetrec sat_rec {};
+    const bool bad_ptrs = !line_1 || !line_2;
+    
+    // keep strlen because we cannot assume the length of the strings and don't want to access out of bounds memory
+    const size_t line_1_len = std::strlen(line_1);
+    const size_t line_2_len = std::strlen(line_2);
+    return from_tle(line_1, line_1_len, line_2, line_2_len, grav_model);
 }
 #endif  // PERTURB_DISABLE_IO
 
 #ifndef PERTURB_DISABLE_IO
 Satellite Satellite::from_tle(
-    std::string &line_1, std::string &line_2, GravModel grav_model
+    const std::string &line_1, const std::string &line_2, GravModel grav_model
 ) {
-    if (line_1.length() < TLE_LINE_LEN || line_2.length() < TLE_LINE_LEN) {
-        return from_tle(nullptr, nullptr);
-    }
-    // FIXME: Find a way to remove usage of &str[0]
-    return from_tle(&line_1[0], &line_2[0], grav_model);
+    return from_tle(line_1.data(), line_1.size(), line_2.data(), line_2.size(), grav_model);
 }
 #endif  // PERTURB_DISABLE_IO
 

--- a/src/perturb.cpp
+++ b/src/perturb.cpp
@@ -189,6 +189,12 @@ Satellite::Satellite(const TwoLineElement &tle, GravModel grav_model) : sat_rec(
 #ifndef PERTURB_DISABLE_IO
     Satellite Satellite::from_tle(const char* line_1, size_t line_1_len, const char* line_2, size_t line_2_len, GravModel grav_model){
         sgp4::elsetrec sat_rec {};
+
+        if(line_1 == nullptr || line_2 == nullptr){
+            sat_rec.error = static_cast<int>(Sgp4Error::UNKNOWN);
+            return Satellite(sat_rec);
+        }
+
         if((line_1_len < TLE_LINE_LEN) || (line_2_len < TLE_LINE_LEN)){
             sat_rec.error = static_cast<int>(Sgp4Error::INVALID_TLE);
             return Satellite(sat_rec);
@@ -220,7 +226,11 @@ Satellite::Satellite(const TwoLineElement &tle, GravModel grav_model) : sat_rec(
 #ifndef PERTURB_DISABLE_IO
 Satellite Satellite::from_tle(const char *line_1, const char *line_2, GravModel grav_model) {
     sgp4::elsetrec sat_rec {};
-    const bool bad_ptrs = !line_1 || !line_2;
+    
+    if(line_1 == nullptr || line_2 == nullptr){
+        sat_rec.error = static_cast<int>(Sgp4Error::UNKNOWN);
+        return Satellite(sat_rec);
+    }
     
     // keep strlen because we cannot assume the length of the strings and don't want to access out of bounds memory
     const size_t line_1_len = std::strlen(line_1);

--- a/src/perturb.cpp
+++ b/src/perturb.cpp
@@ -51,6 +51,8 @@ JulianDate::JulianDate(DateTime t) {
     jd_frac = tmp_jd_frac;
 }
 
+JulianDate::JulianDate(std::chrono::system_clock::time_point t) : JulianDate(to_julian(t)) {}
+
 DateTime JulianDate::to_datetime() const {
     DateTime t {};
     sgp4::invjday_SGP4(jd, jd_frac, t.year, t.month, t.day, t.hour, t.min, t.sec);
@@ -115,6 +117,44 @@ bool JulianDate::operator<=(const JulianDate &rhs) const {
 
 bool JulianDate::operator>=(const JulianDate &rhs) const {
     return (*this - rhs) >= 0;
+}
+
+JulianDate to_julian(std::chrono::system_clock::time_point time){
+    using int_days = std::chrono::duration<std::int64_t, std::ratio<86400>>;
+    using float_days = std::chrono::duration<double, std::ratio<86400>>;
+
+    // convert in system clock integers to mitigate information loss during conversion
+    const std::chrono::system_clock::duration since_epoch = time.time_since_epoch();
+    int_days days_since_unix_epoch = std::chrono::duration_cast<int_days>(since_epoch);
+    std::chrono::system_clock::duration residual_day_since_unix_epoch = since_epoch - std::chrono::duration_cast<std::chrono::system_clock::duration>(days_since_unix_epoch);
+
+    // fix rounding so that duration cast behaves like floor
+    if(residual_day_since_unix_epoch < std::chrono::system_clock::duration(0)){
+        days_since_unix_epoch -= int_days(1);
+        residual_day_since_unix_epoch += int_days(1);
+    }
+
+    // convert days to julian
+    // Unix epoch:
+    // 1970-01-01 00:00:00 UTC = JD 2440587.5
+    int_days julian_days = days_since_unix_epoch + int_days(2440587);
+
+    // convert residual to julian residual
+    std::chrono::system_clock::duration residual = residual_day_since_unix_epoch + std::chrono::hours(12);
+    
+    // Normalize JD fraction into [0, 1).
+    if(residual >= int_days(1)){
+        julian_days += int_days(1);
+        residual -= int_days(1);
+    }
+
+    // convert from integers to double
+    const double jd_days = static_cast<double>(julian_days.count());
+    const double jd_fraction = std::chrono::duration_cast<float_days>(residual).count();
+
+    // construct julian
+    const JulianDate jd(jd_days, jd_fraction);
+    return jd;
 }
 
 ClassicalOrbitalElements::ClassicalOrbitalElements(
@@ -278,41 +318,7 @@ Sgp4Error Satellite::propagate(const JulianDate jd, StateVector &sv) {
 }
 
 Sgp4Error Satellite::propagate(std::chrono::system_clock::time_point time, StateVector &sv){
-    using int_days = std::chrono::duration<std::int64_t, std::ratio<86400>>;
-    using float_days = std::chrono::duration<double, std::ratio<86400>>;
-
-    // convert in system clock integers to mitigate information loss during conversion
-    const std::chrono::system_clock::duration since_epoch = time.time_since_epoch();
-    int_days days_since_unix_epoch = std::chrono::duration_cast<int_days>(since_epoch);
-    std::chrono::system_clock::duration residual_day_since_unix_epoch = since_epoch - std::chrono::duration_cast<std::chrono::system_clock::duration>(days_since_unix_epoch);
-
-    // fix rounding so that duration cast behaves like floor
-    if(residual_day_since_unix_epoch < std::chrono::system_clock::duration(0)){
-        days_since_unix_epoch -= int_days(1);
-        residual_day_since_unix_epoch += int_days(1);
-    }
-
-    // convert days to julian
-    // Unix epoch:
-    // 1970-01-01 00:00:00 UTC = JD 2440587.5
-    int_days julian_days = days_since_unix_epoch + int_days(2440587);
-
-    // convert residual to julian residual
-    std::chrono::system_clock::duration residual = residual_day_since_unix_epoch + std::chrono::hours(12);
-    
-    // Normalize JD fraction into [0, 1).
-    if(residual >= int_days(1)){
-        julian_days += int_days(1);
-        residual -= int_days(1);
-    }
-
-    // convert from integers to double
-    const double jd_days = static_cast<double>(julian_days.count());
-    const double jd_fraction = std::chrono::duration_cast<float_days>(residual).count();
-
-    const JulianDate jd(jd_days, jd_fraction);
-
-    return this->propagate(jd, sv);
+    return this->propagate(JulianDate(time), sv);
 }
 
 }  // namespace perturb

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -21,7 +21,13 @@ FetchContent_Declare(
 FetchContent_MakeAvailable(doctest)
 
 add_executable(test_perturb test_perturb.cpp)
-target_link_libraries(test_perturb PRIVATE perturb doctest)
+target_link_libraries(test_perturb PRIVATE perturb doctest::doctest)
+
+# register test for ctest
+add_test(NAME test_perturb COMMAND test_perturb)
+set_tests_properties(test_perturb PROPERTIES
+    WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}/tests"
+)
 
 # Restore previous
 if(DEFINED CMAKE_CXX_CLANG_TIDY_save)


### PR DESCRIPTION
Changes:
-----------
+ `const` correctness. `from_tle()` now reads from `const char*` and `const std::string&` (instead of: `char*` and `std::string&`) to not have side-effects or unknowingly mutate the string of the user:
  + `static Satellite from_tle(const std::string &line_1, const std::string &line_2, GravModel grav_model = GravModel::WGS72);`
  + `static Satellite from_tle(const char *line_1, const char *line_2, GravModel grav_model = GravModel::WGS72);`

Additions:
------------
+ Safer `from_tle()` function that reads from `const char*` with an additional string length parameter:
  + `static Satellite from_tle(const char* line_1, size_t line_1_len, const char* line_2, size_t line_2_len, GravModel grav_model);`
+ Propagate functions supporting chrono time points and durations:
  + `propagate_from_epoch(std::chrono::system_clock::duration time_epoch, StateVector &sv);`
  + `propagate(std::chrono::system_clock::time_point time, StateVector &sv)`

All existing tests are Passing